### PR TITLE
Fix arm64 wheels for python 3.10

### DIFF
--- a/.github/workflows/build-aarch64.yml
+++ b/.github/workflows/build-aarch64.yml
@@ -29,7 +29,7 @@ jobs:
         source venv/bin/activate
         python -m pip install --upgrade pip
         pip install wheel
-        pip install cibuildwheel==2.3.1
+        pip install cibuildwheel==2.4.0
 
     - name: Lint source with flake8
       run: |

--- a/.github/workflows/build-aarch64.yml
+++ b/.github/workflows/build-aarch64.yml
@@ -43,7 +43,7 @@ jobs:
         python -m cibuildwheel --output-dir dist
       env:
         # build python 3.7, 3.8, 3.9, 3.10
-        CIBW_BUILD: cp37* cp38-* cp39-* cp-310-*
+        CIBW_BUILD: cp37* cp38-* cp39-* cp310-*
         CIBW_SKIP: '*-musllinux_*'
         CIBW_MANYLINUX_AARCH64_IMAGE: manylinux2014
         # we need boost

--- a/.github/workflows/build-aarch64.yml
+++ b/.github/workflows/build-aarch64.yml
@@ -42,8 +42,8 @@ jobs:
         source venv/bin/activate
         python -m cibuildwheel --output-dir dist
       env:
-        # build python 3.7 and 3.8
-        CIBW_BUILD: cp37* cp38-* cp39-* cp-310
+        # build python 3.7, 3.8, 3.9, 3.10
+        CIBW_BUILD: cp37* cp38-* cp39-* cp-310-*
         CIBW_SKIP: '*-musllinux_*'
         CIBW_MANYLINUX_AARCH64_IMAGE: manylinux2014
         # we need boost


### PR DESCRIPTION
I think we either need to tag a new version of this and PR in chia-blockchain, or I can just make a new branch to build the 1.1 version of this with the fixed CI