### PR TITLE
fix: build on freebsd

### DIFF
--- a/src/compat/endian.h
+++ b/src/compat/endian.h
@@ -14,7 +14,7 @@
 #include <stdint.h>
 
 #if defined(HAVE_ENDIAN_H)
-#include <endian.h>
+#include "endian.h"
 #elif defined(HAVE_SYS_ENDIAN_H)
 #include <sys/endian.h>
 #endif


### PR DESCRIPTION
I was just upgrading to chia 2.1.0 on my FreeBSD node, when I found that `chiabip158` stopped building with the following error:

```
      cc -pthread -Wno-unused-result -Wsign-compare -Wunreachable-code -DNDEBUG -O2 -pipe -fstack-protector-strong -fno-strict-aliasing -fPIC -I/tmp/pip-build-env-02q35h0z/overlay/lib/python3.9/site-packages/pybind11/include -I/tmp/pip-build-env-02q35h0z/overlay/lib/python3.9/site-packages/pybind11/include -Isrc -I/root/chia-blockchain/venv/include -I/usr/local/include/python3.9 -c python-bindings/chiabip158.cpp -o build/temp.freebsd-13.1-RELEASE-p7-amd64-cpython-39/python-bindings/chiabip158.o -DVERSION_INFO=\"1.3\" -std=c++17 -fvisibility=hidden
      In file included from python-bindings/chiabip158.cpp:19:
      In file included from python-bindings/PyBIP158.h:18:
      In file included from src/blockfilter.h:13:
      In file included from src/primitives/block.h:9:
      In file included from src/primitives/transaction.h:11:
      In file included from src/script/script.h:9:
      In file included from src/crypto/common.h:15:
      src/compat/endian.h:17:10: error: 'endian.h' file not found with <angled> include; use "quotes" instead
      #include <endian.h>
               ^~~~~~~~~~
               "endian.h"
      1 error generated.
      error: command '/usr/bin/cc' failed with exit code 1
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for chiabip158
Successfully built chia-blockchain
Failed to build chiabip158
ERROR: Could not build wheels for chiabip158, which is required to install pyproject.toml-based projects
```

I tried this fix, and it seemed to work