### PR TITLE
Upload sdist as `package-sdist`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -166,7 +166,7 @@ jobs:
     - name: Upload artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: packages
+        name: packages-sdist
         path: ./dist
 
   check:


### PR DESCRIPTION
The workflow was using the name `package` in the upload-artifact job for the sdist - however, the download job was asking for `packages-*`. Note the dash. So I belive the sdist was getting missed and not uploaded to pypi

(The source distribution is missing from pypi)

use a name of `package-dist` which I hope will fix this.