### PR TITLE
cleanup warnings

### DIFF
--- a/python-bindings/PyBIP158.cpp
+++ b/python-bindings/PyBIP158.cpp
@@ -17,10 +17,10 @@
 PyBIP158::PyBIP158(std::vector< std::vector< unsigned char > >& hashes)
 {
     GCSFilter::ElementSet elements;
-    for (int i = 0; i < hashes.size(); ++i)
+    for (size_t i = 0; i < hashes.size(); ++i)
     {
         GCSFilter::Element element(hashes[i].size());
-        for(int j=0;j<hashes[i].size();j++)
+        for(size_t j=0;j<hashes[i].size();j++)
         {
             element[j] = hashes[i][j];
         }
@@ -47,7 +47,7 @@ PyBIP158::~PyBIP158()
 bool PyBIP158::Match(std::vector< unsigned char >& hash)
 {
     GCSFilter::Element element(hash.size());
-    for(int j=0;j<hash.size();j++)
+    for(size_t j=0;j<hash.size();j++)
     {
         element[j] = hash[j];
     }
@@ -59,10 +59,10 @@ bool PyBIP158::MatchAny(std::vector< std::vector< unsigned char > >& hashes)
 {
     GCSFilter::ElementSet elements;
     
-    for (int i = 0; i < hashes.size(); ++i)
+    for (size_t i = 0; i < hashes.size(); ++i)
     {
         GCSFilter::Element element(hashes[i].size());
-        for(int j=0;j<hashes[i].size();j++)
+        for(size_t j=0;j<hashes[i].size();j++)
         {
             element[j] = hashes[i][j];
         }

--- a/src/blockfilter.cpp
+++ b/src/blockfilter.cpp
@@ -165,10 +165,9 @@ bool GCSFilter::MatchInternal(const uint64_t* element_hashes, size_t size) const
     VectorReader stream(GCS_SER_TYPE, GCS_SER_VERSION, m_encoded, 0);
 
     // Seek forward by size of N
-#ifndef NDEBUG
     uint64_t N = ReadCompactSize(stream);
+    (void)N; // suppress unused variable warning
     assert(N == m_N);
-#endif
 
     BitStreamReader<VectorReader> bitreader(stream);
 

--- a/src/blockfilter.cpp
+++ b/src/blockfilter.cpp
@@ -165,8 +165,10 @@ bool GCSFilter::MatchInternal(const uint64_t* element_hashes, size_t size) const
     VectorReader stream(GCS_SER_TYPE, GCS_SER_VERSION, m_encoded, 0);
 
     // Seek forward by size of N
+#ifndef NDEBUG
     uint64_t N = ReadCompactSize(stream);
     assert(N == m_N);
+#endif
 
     BitStreamReader<VectorReader> bitreader(stream);
 

--- a/src/crypto/sha256.cpp
+++ b/src/crypto/sha256.cpp
@@ -462,6 +462,7 @@ TransformD64Type TransformD64_2way = nullptr;
 TransformD64Type TransformD64_4way = nullptr;
 TransformD64Type TransformD64_8way = nullptr;
 
+#ifndef NDEBUG
 bool SelfTest() {
     // Input state (equal to the initial SHA256 state)
     static const uint32_t init[8] = {
@@ -546,7 +547,7 @@ bool SelfTest() {
 
     return true;
 }
-
+#endif
 
 #if defined(USE_ASM) && (defined(__x86_64__) || defined(__amd64__) || defined(__i386__))
 // We can't use cpuid.h's __get_cpuid as it does not support subleafs.


### PR DESCRIPTION
The default build system here uses `-DNDEBUG` which disables asserts. 
used `size_t` instead of `int` in some loops