### PR TITLE
remove mmacosx-version-min

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,7 @@ class BuildExt(build_ext):
     }
 
     if sys.platform == "darwin":
-        darwin_opts = ["-stdlib=libc++", "-mmacosx-version-min=10.14"]
+        darwin_opts = ["-stdlib=libc++"]
         c_opts["unix"] += darwin_opts  # type: ignore
         l_opts["unix"] += darwin_opts  # type: ignore
 


### PR DESCRIPTION
We use MACOSX_DEPLOYMENT_VERSION when we build the wheel and so we don't need to specify `-mmacosx-version-min` at the compiler.

They do the same thing - but you need to set the envvar to get the wheel named properly