### PR TITLE
Add python 3.14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,26 +45,31 @@ jobs:
             runs-on:
               intel: [windows-latest]
         python:
-          - major-dot-minor: '3.9'
-            cibw-build: 'cp39-*'
-            manylinux: manylinux_2_28
-            matrix: '3.9'
           - major-dot-minor: '3.10'
             cibw-build: 'cp310-*'
             manylinux: manylinux_2_28
             matrix: '3.10'
+            cibuildwheel: 'cibuildwheel==2.23.3'
           - major-dot-minor: '3.11'
             cibw-build: 'cp311-*'
             manylinux: manylinux_2_28
             matrix: '3.11'
+            cibuildwheel: 'cibuildwheel==3.2.1'
           - major-dot-minor: '3.12'
             cibw-build: 'cp312-*'
             manylinux: manylinux_2_28
             matrix: '3.12'
+            cibuildwheel: 'cibuildwheel==3.2.1'
           - major-dot-minor: '3.13'
             cibw-build: 'cp313-*'
             manylinux: manylinux_2_28
             matrix: '3.13'
+            cibuildwheel: 'cibuildwheel==3.2.1'
+          - major-dot-minor: '3.14'
+            cibw-build: 'cp314-*'
+            manylinux: manylinux_2_28
+            matrix: '3.14'
+            cibuildwheel: 'cibuildwheel==3.2.1'
         arch:
           - name: ARM
             matrix: arm
@@ -107,7 +112,7 @@ jobs:
         CIBW_BUILD_VERBOSITY_LINUX: 0
         CIBW_BUILD_VERBOSITY_WINDOWS: 0
         CIBW_BUILD: ${{ matrix.python.cibw-build }}
-        CIBW_SKIP: '*-manylinux_i686 *-win32 *-musllinux_*'
+        CIBW_SKIP: 'cp31?t-* *-manylinux_i686 *-win32 *-musllinux_*'
         CIBW_MANYLINUX_AARCH64_IMAGE: ${{ matrix.python.manylinux }}
         CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.python.manylinux }}
         CIBW_BEFORE_ALL_LINUX: >
@@ -122,7 +127,7 @@ jobs:
         CIBW_TEST_REQUIRES: pytest
         CIBW_TEST_COMMAND: py.test -v {project}/tests
       run:
-        pipx run --spec='cibuildwheel==2.21.3' cibuildwheel --output-dir dist 2>&1
+        pipx run --spec=${{ matrix.python.cibuildwheel }} cibuildwheel --output-dir dist 2>&1
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v4
@@ -143,8 +148,8 @@ jobs:
               arm: [Linux, ARM64]
               intel: [ubuntu-latest]
         python:
-          - major-dot-minor: '3.10'
-            matrix: '3.10'
+          - major-dot-minor: '3.12'
+            matrix: '3.12'
         arch:
           - name: Intel
             matrix: intel
@@ -186,8 +191,8 @@ jobs:
               arm: [Linux, ARM64]
               intel: [ubuntu-latest]
         python:
-          - major-dot-minor: '3.10'
-            matrix: '3.10'
+          - major-dot-minor: '3.12'
+            matrix: '3.12'
         arch:
           - name: Intel
             matrix: intel
@@ -232,8 +237,8 @@ jobs:
               arm: [Linux, ARM64]
               intel: [ubuntu-latest]
         python:
-          - major-dot-minor: '3.10'
-            matrix: '3.10'
+          - major-dot-minor: '3.12'
+            matrix: '3.12'
         arch:
           - name: Intel
             matrix: intel

--- a/src/compat/endian.h
+++ b/src/compat/endian.h
@@ -15,7 +15,7 @@
 
 #if defined(HAVE_ENDIAN_H)
 #include <endian.h>
-#elif defined(HAVE_SYS_ENDIAN_H)
+#elif defined(HAVE_SYS_ENDIAN_H) && !defined(__APPLE__)
 #include <sys/endian.h>
 #endif
 


### PR DESCRIPTION
Add python 3.14
Update skip pattern to not make freethreading wheels
Remove python 3.9 support
Update cibuildwheel for python 3.10 to latest 2 series (2.23.3)
Update cibuildwheel for python 3.11+ to latest 3 series (3.2.1)

update sdist python version to 3.12